### PR TITLE
Add Terraform PoC infrastructure

### DIFF
--- a/infra/README.md
+++ b/infra/README.md
@@ -1,0 +1,61 @@
+# PoC インフラ (Terraform)
+
+このディレクトリには、ECS(Fargate)上で API(Go) と WEB(Next.js) を動作させるための最小構成 Terraform コードが含まれます。コストを最優先し、単一の ALB や最小限のリソースで構成されています。
+
+## 前提ツール
+
+- [Terraform](https://www.terraform.io/) >= 1.6
+- [AWS CLI](https://aws.amazon.com/cli/)
+- [Docker](https://www.docker.com/)
+
+## 初期セットアップ
+
+1. **ECR へログインしイメージをビルド & プッシュ**
+
+   ```bash
+   # 例: 東京リージョン
+   aws ecr get-login-password --region ap-northeast-1 \
+     | docker login --username AWS --password-stdin <ACCOUNT_ID>.dkr.ecr.ap-northeast-1.amazonaws.com
+
+   # API
+   docker build -t api:latest ./api
+   docker tag api:latest <ACCOUNT_ID>.dkr.ecr.ap-northeast-1.amazonaws.com/api:latest
+   docker push <ACCOUNT_ID>.dkr.ecr.ap-northeast-1.amazonaws.com/api:latest
+
+   # WEB
+   docker build -t web:latest ./web
+   docker tag web:latest <ACCOUNT_ID>.dkr.ecr.ap-northeast-1.amazonaws.com/web:latest
+   docker push <ACCOUNT_ID>.dkr.ecr.ap-northeast-1.amazonaws.com/web:latest
+   ```
+
+2. **`terraform.tfvars` を作成**
+
+   ```hcl
+   db_password        = "your-secret"
+   api_container_image = "<ACCOUNT_ID>.dkr.ecr.ap-northeast-1.amazonaws.com/api:latest"
+   web_container_image = "<ACCOUNT_ID>.dkr.ecr.ap-northeast-1.amazonaws.com/web:latest"
+   ```
+
+3. **Terraform 実行**
+
+   ```bash
+   terraform init
+   terraform apply -auto-approve
+   ```
+
+4. **動作確認**
+
+   出力された `alb_dns_name` にブラウザでアクセスして動作を確認します。
+   - `/` : WEB サービス
+   - `/api/healthz` : API サービス
+
+## コスト注意点
+
+- ALB ×1, Fargate タスク ×2, RDS ×1, S3(公開) などが課金対象です。
+- 利用後は必ずリソースを削除してください。
+
+## 片付け
+
+```bash
+terraform destroy -auto-approve
+```

--- a/infra/alb.tf
+++ b/infra/alb.tf
@@ -1,0 +1,57 @@
+resource "aws_lb" "this" {
+  name               = "${var.name_prefix}-alb"
+  load_balancer_type = "application"
+  security_groups    = [aws_security_group.alb.id]
+  subnets            = aws_subnet.public[*].id
+  tags               = local.tags
+}
+
+resource "aws_lb_target_group" "api" {
+  name        = "${var.name_prefix}-api-tg"
+  port        = var.api_container_port
+  protocol    = "HTTP"
+  vpc_id      = aws_vpc.this.id
+  target_type = "ip"
+  health_check {
+    path = "/healthz"
+  }
+  tags = local.tags
+}
+
+resource "aws_lb_target_group" "web" {
+  name        = "${var.name_prefix}-web-tg"
+  port        = var.web_container_port
+  protocol    = "HTTP"
+  vpc_id      = aws_vpc.this.id
+  target_type = "ip"
+  health_check {
+    path = "/"
+  }
+  tags = local.tags
+}
+
+resource "aws_lb_listener" "http" {
+  load_balancer_arn = aws_lb.this.arn
+  port              = 80
+  protocol          = "HTTP"
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.web.arn
+  }
+}
+
+resource "aws_lb_listener_rule" "api" {
+  listener_arn = aws_lb_listener.http.arn
+  priority     = 10
+
+  action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.api.arn
+  }
+
+  condition {
+    path_pattern {
+      values = ["/api/*"]
+    }
+  }
+}

--- a/infra/ecr.tf
+++ b/infra/ecr.tf
@@ -1,0 +1,45 @@
+resource "aws_ecr_repository" "api" {
+  name                 = "api"
+  image_tag_mutability = "MUTABLE"
+  tags                 = local.tags
+
+  lifecycle_policy {
+    policy = jsonencode({
+      rules = [{
+        rulePriority = 1
+        description  = "Keep last 5 images"
+        selection = {
+          tagStatus   = "any"
+          countType   = "imageCountMoreThan"
+          countNumber = 5
+        }
+        action = {
+          type = "expire"
+        }
+      }]
+    })
+  }
+}
+
+resource "aws_ecr_repository" "web" {
+  name                 = "web"
+  image_tag_mutability = "MUTABLE"
+  tags                 = local.tags
+
+  lifecycle_policy {
+    policy = jsonencode({
+      rules = [{
+        rulePriority = 1
+        description  = "Keep last 5 images"
+        selection = {
+          tagStatus   = "any"
+          countType   = "imageCountMoreThan"
+          countNumber = 5
+        }
+        action = {
+          type = "expire"
+        }
+      }]
+    })
+  }
+}

--- a/infra/ecs_cluster.tf
+++ b/infra/ecs_cluster.tf
@@ -1,0 +1,31 @@
+resource "aws_ecs_cluster" "this" {
+  name = "${var.name_prefix}-cluster"
+  tags = local.tags
+}
+
+data "aws_iam_policy_document" "ecs_task_assume" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["ecs-tasks.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "task_execution" {
+  name               = "${var.name_prefix}-task-execution-role"
+  assume_role_policy = data.aws_iam_policy_document.ecs_task_assume.json
+  tags               = local.tags
+}
+
+resource "aws_iam_role_policy_attachment" "task_execution" {
+  role       = aws_iam_role.task_execution.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+}
+
+resource "aws_iam_role" "task" {
+  name               = "${var.name_prefix}-task-role"
+  assume_role_policy = data.aws_iam_policy_document.ecs_task_assume.json
+  tags               = local.tags
+}

--- a/infra/ecs_services_api.tf
+++ b/infra/ecs_services_api.tf
@@ -1,0 +1,58 @@
+resource "aws_cloudwatch_log_group" "api" {
+  name              = "/${var.name_prefix}/api"
+  retention_in_days = 7
+  tags              = local.tags
+}
+
+resource "aws_ecs_task_definition" "api" {
+  family                   = "${var.name_prefix}-api"
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+  cpu                      = "512"
+  memory                   = "1024"
+  execution_role_arn       = aws_iam_role.task_execution.arn
+  task_role_arn            = aws_iam_role.task.arn
+
+  container_definitions = jsonencode([
+    {
+      name  = "api"
+      image = var.api_container_image
+      portMappings = [{
+        containerPort = var.api_container_port
+        protocol      = "tcp"
+      }]
+      logConfiguration = {
+        logDriver = "awslogs"
+        options = {
+          awslogs-group         = aws_cloudwatch_log_group.api.name
+          awslogs-region        = var.region
+          awslogs-stream-prefix = "api"
+        }
+      }
+    }
+  ])
+  tags = local.tags
+}
+
+resource "aws_ecs_service" "api" {
+  name            = "${var.name_prefix}-api"
+  cluster         = aws_ecs_cluster.this.id
+  task_definition = aws_ecs_task_definition.api.arn
+  desired_count   = 1
+  launch_type     = "FARGATE"
+
+  network_configuration {
+    subnets          = aws_subnet.public[*].id
+    security_groups  = [aws_security_group.ecs.id]
+    assign_public_ip = true
+  }
+
+  load_balancer {
+    target_group_arn = aws_lb_target_group.api.arn
+    container_name   = "api"
+    container_port   = var.api_container_port
+  }
+
+  depends_on = [aws_lb_listener_rule.api]
+  tags       = local.tags
+}

--- a/infra/ecs_services_web.tf
+++ b/infra/ecs_services_web.tf
@@ -1,0 +1,58 @@
+resource "aws_cloudwatch_log_group" "web" {
+  name              = "/${var.name_prefix}/web"
+  retention_in_days = 7
+  tags              = local.tags
+}
+
+resource "aws_ecs_task_definition" "web" {
+  family                   = "${var.name_prefix}-web"
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+  cpu                      = "512"
+  memory                   = "1024"
+  execution_role_arn       = aws_iam_role.task_execution.arn
+  task_role_arn            = aws_iam_role.task.arn
+
+  container_definitions = jsonencode([
+    {
+      name  = "web"
+      image = var.web_container_image
+      portMappings = [{
+        containerPort = var.web_container_port
+        protocol      = "tcp"
+      }]
+      logConfiguration = {
+        logDriver = "awslogs"
+        options = {
+          awslogs-group         = aws_cloudwatch_log_group.web.name
+          awslogs-region        = var.region
+          awslogs-stream-prefix = "web"
+        }
+      }
+    }
+  ])
+  tags = local.tags
+}
+
+resource "aws_ecs_service" "web" {
+  name            = "${var.name_prefix}-web"
+  cluster         = aws_ecs_cluster.this.id
+  task_definition = aws_ecs_task_definition.web.arn
+  desired_count   = 1
+  launch_type     = "FARGATE"
+
+  network_configuration {
+    subnets          = aws_subnet.public[*].id
+    security_groups  = [aws_security_group.ecs.id]
+    assign_public_ip = true
+  }
+
+  load_balancer {
+    target_group_arn = aws_lb_target_group.web.arn
+    container_name   = "web"
+    container_port   = var.web_container_port
+  }
+
+  depends_on = [aws_lb_listener.http]
+  tags       = local.tags
+}

--- a/infra/outputs.tf
+++ b/infra/outputs.tf
@@ -1,0 +1,27 @@
+output "alb_dns_name" {
+  value = aws_lb.this.dns_name
+}
+
+output "web_target_group_arn" {
+  value = aws_lb_target_group.web.arn
+}
+
+output "api_target_group_arn" {
+  value = aws_lb_target_group.api.arn
+}
+
+output "ecr_api_url" {
+  value = aws_ecr_repository.api.repository_url
+}
+
+output "ecr_web_url" {
+  value = aws_ecr_repository.web.repository_url
+}
+
+output "rds_endpoint" {
+  value = aws_db_instance.this.endpoint
+}
+
+output "s3_website_endpoint" {
+  value = aws_s3_bucket_website_configuration.assets.website_endpoint
+}

--- a/infra/providers.tf
+++ b/infra/providers.tf
@@ -1,0 +1,5 @@
+provider "aws" {
+  region = var.region
+}
+
+provider "random" {}

--- a/infra/rds.tf
+++ b/infra/rds.tf
@@ -1,0 +1,24 @@
+resource "aws_db_subnet_group" "this" {
+  name       = "${var.name_prefix}-db-subnet-group"
+  subnet_ids = aws_subnet.private[*].id
+  tags       = local.tags
+}
+
+resource "aws_db_instance" "this" {
+  identifier             = "${var.name_prefix}-db"
+  engine                 = "mysql"
+  engine_version         = "8.0"
+  instance_class         = "db.t3.micro"
+  allocated_storage      = 20
+  storage_type           = "gp3"
+  name                   = var.db_name
+  username               = var.db_username
+  password               = var.db_password
+  db_subnet_group_name   = aws_db_subnet_group.this.name
+  vpc_security_group_ids = [aws_security_group.rds.id]
+  skip_final_snapshot    = true
+  multi_az               = false
+  publicly_accessible    = false
+  deletion_protection    = false
+  tags                   = local.tags
+}

--- a/infra/s3.tf
+++ b/infra/s3.tf
@@ -1,0 +1,44 @@
+resource "random_pet" "this" {
+  length = 2
+}
+
+resource "aws_s3_bucket" "assets" {
+  bucket        = "${var.name_prefix}-static-assets-${random_pet.this.id}"
+  force_destroy = true
+  tags          = local.tags
+}
+
+resource "aws_s3_bucket_public_access_block" "assets" {
+  bucket = aws_s3_bucket.assets.id
+
+  block_public_acls       = false
+  block_public_policy     = false
+  ignore_public_acls      = false
+  restrict_public_buckets = false
+}
+
+resource "aws_s3_bucket_acl" "assets" {
+  bucket = aws_s3_bucket.assets.id
+  acl    = "public-read"
+}
+
+resource "aws_s3_bucket_website_configuration" "assets" {
+  bucket = aws_s3_bucket.assets.id
+  index_document {
+    suffix = "index.html"
+  }
+}
+
+resource "aws_s3_bucket_policy" "assets" {
+  bucket = aws_s3_bucket.assets.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect    = "Allow"
+      Principal = "*"
+      Action    = ["s3:GetObject"]
+      Resource  = ["${aws_s3_bucket.assets.arn}/*"]
+    }]
+  })
+}

--- a/infra/security.tf
+++ b/infra/security.tf
@@ -1,0 +1,72 @@
+resource "aws_security_group" "alb" {
+  name        = "${var.name_prefix}-alb-sg"
+  description = "Allow HTTP inbound"
+  vpc_id      = aws_vpc.this.id
+
+  ingress {
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = local.tags
+}
+
+resource "aws_security_group" "ecs" {
+  name        = "${var.name_prefix}-ecs-sg"
+  description = "Allow from ALB"
+  vpc_id      = aws_vpc.this.id
+
+  ingress {
+    from_port       = var.api_container_port
+    to_port         = var.api_container_port
+    protocol        = "tcp"
+    security_groups = [aws_security_group.alb.id]
+  }
+
+  ingress {
+    from_port       = var.web_container_port
+    to_port         = var.web_container_port
+    protocol        = "tcp"
+    security_groups = [aws_security_group.alb.id]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = local.tags
+}
+
+resource "aws_security_group" "rds" {
+  name        = "${var.name_prefix}-rds-sg"
+  description = "Allow MySQL from ECS"
+  vpc_id      = aws_vpc.this.id
+
+  ingress {
+    from_port       = 3306
+    to_port         = 3306
+    protocol        = "tcp"
+    security_groups = [aws_security_group.ecs.id]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = local.tags
+}

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -1,0 +1,52 @@
+variable "region" {
+  type    = string
+  default = "ap-northeast-1"
+}
+
+variable "name_prefix" {
+  type    = string
+  default = "poc"
+}
+
+variable "db_name" {
+  type    = string
+  default = "appdb"
+}
+
+variable "db_username" {
+  type    = string
+  default = "app"
+}
+
+variable "db_password" {
+  type      = string
+  sensitive = true
+}
+
+variable "api_container_port" {
+  type    = number
+  default = 8080
+}
+
+variable "web_container_port" {
+  type    = number
+  default = 3000
+}
+
+variable "api_container_image" {
+  type    = string
+  default = "api:latest"
+}
+
+variable "web_container_image" {
+  type    = string
+  default = "web:latest"
+}
+
+locals {
+  tags = {
+    Project     = var.name_prefix
+    Owner       = "dev"
+    Environment = "dev"
+  }
+}

--- a/infra/versions.tf
+++ b/infra/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.6"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.0"
+    }
+  }
+}

--- a/infra/vpc.tf
+++ b/infra/vpc.tf
@@ -1,0 +1,56 @@
+data "aws_availability_zones" "available" {}
+
+resource "aws_vpc" "this" {
+  cidr_block = "10.10.0.0/16"
+  tags       = local.tags
+}
+
+resource "aws_internet_gateway" "this" {
+  vpc_id = aws_vpc.this.id
+  tags   = local.tags
+}
+
+resource "aws_subnet" "public" {
+  count                   = 2
+  vpc_id                  = aws_vpc.this.id
+  cidr_block              = element(["10.10.0.0/24", "10.10.1.0/24"], count.index)
+  availability_zone       = data.aws_availability_zones.available.names[count.index]
+  map_public_ip_on_launch = true
+  tags                    = merge(local.tags, { "Name" = "${var.name_prefix}-public-${count.index}" })
+}
+
+resource "aws_subnet" "private" {
+  count             = 2
+  vpc_id            = aws_vpc.this.id
+  cidr_block        = element(["10.10.10.0/24", "10.10.11.0/24"], count.index)
+  availability_zone = data.aws_availability_zones.available.names[count.index]
+  tags              = merge(local.tags, { "Name" = "${var.name_prefix}-private-${count.index}" })
+}
+
+resource "aws_route_table" "public" {
+  vpc_id = aws_vpc.this.id
+  tags   = local.tags
+}
+
+resource "aws_route" "public_internet_access" {
+  route_table_id         = aws_route_table.public.id
+  destination_cidr_block = "0.0.0.0/0"
+  gateway_id             = aws_internet_gateway.this.id
+}
+
+resource "aws_route_table_association" "public" {
+  count          = 2
+  subnet_id      = aws_subnet.public[count.index].id
+  route_table_id = aws_route_table.public.id
+}
+
+resource "aws_route_table" "private" {
+  vpc_id = aws_vpc.this.id
+  tags   = local.tags
+}
+
+resource "aws_route_table_association" "private" {
+  count          = 2
+  subnet_id      = aws_subnet.private[count.index].id
+  route_table_id = aws_route_table.private.id
+}


### PR DESCRIPTION
## Summary
- scaffold minimal-cost AWS infrastructure with ECS Fargate API/WEB services, ALB routing, RDS MySQL and S3 static hosting
- include ECR repositories, security groups and CloudWatch logging
- document setup and usage in Japanese README

## Testing
- `terraform fmt -check`
- `terraform init -input=false` *(fails: Failed to query available provider packages: Forbidden)*
- `terraform validate` *(fails: Missing required provider)*

------
https://chatgpt.com/codex/tasks/task_e_68bbc198b0b083258a24400bdc694a46